### PR TITLE
change arrays to lists, plugin interface to return a list of syslog m…

### DIFF
--- a/src/main/java/com/teragrep/akv_01/event/ParsedEventListFactory.java
+++ b/src/main/java/com/teragrep/akv_01/event/ParsedEventListFactory.java
@@ -45,12 +45,9 @@
  */
 package com.teragrep.akv_01.event;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
-public final class ParsedEventArrayFactory {
+public final class ParsedEventListFactory {
 
     private final String[] payloads;
     private final Map<String, Object> partitionCtx;
@@ -59,7 +56,7 @@ public final class ParsedEventArrayFactory {
     private final List<Object> enqueuedTimeUtcList;
     private final List<String> offsetList;
 
-    public ParsedEventArrayFactory(
+    public ParsedEventListFactory(
             final String[] payloads,
             final Map<String, Object> partitionCtx,
             final Map<String, Object>[] propertiesArray,
@@ -75,17 +72,20 @@ public final class ParsedEventArrayFactory {
         this.offsetList = offsetList;
     }
 
-    public ParsedEvent[] asArray() {
-        final ParsedEvent[] events = new ParsedEvent[payloads.length];
+    public List<ParsedEvent> asList() {
+        final List<ParsedEvent> events = new ArrayList<>(payloads.length);
         for (int i = 0; i < payloads.length; i++) {
-            events[i] = new EventImpl(
-                    payloads[i],
-                    partitionCtx,
-                    propertiesArray[i],
-                    systemPropertiesArray[i],
-                    enqueuedTimeUtcList.get(i),
-                    offsetList.get(i)
-            ).parsedEvent();
+            events
+                    .add(
+                            new EventImpl(
+                                    payloads[i],
+                                    partitionCtx,
+                                    propertiesArray[i],
+                                    systemPropertiesArray[i],
+                                    enqueuedTimeUtcList.get(i),
+                                    offsetList.get(i)
+                            ).parsedEvent()
+                    );
         }
         return events;
     }
@@ -95,7 +95,7 @@ public final class ParsedEventArrayFactory {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ParsedEventArrayFactory that = (ParsedEventArrayFactory) o;
+        ParsedEventListFactory that = (ParsedEventListFactory) o;
         return Objects.deepEquals(payloads, that.payloads) && Objects.equals(partitionCtx, that.partitionCtx)
                 && Objects.deepEquals(propertiesArray, that.propertiesArray) && Objects.deepEquals(systemPropertiesArray, that.systemPropertiesArray) && Objects.equals(enqueuedTimeUtcList, that.enqueuedTimeUtcList) && Objects.equals(offsetList, that.offsetList);
     }

--- a/src/main/java/com/teragrep/akv_01/event/ParsedEventListFactory.java
+++ b/src/main/java/com/teragrep/akv_01/event/ParsedEventListFactory.java
@@ -75,17 +75,19 @@ public final class ParsedEventListFactory {
     public List<ParsedEvent> asList() {
         final List<ParsedEvent> events = new ArrayList<>(payloads.length);
         for (int i = 0; i < payloads.length; i++) {
-            events
-                    .add(
-                            new EventImpl(
-                                    payloads[i],
-                                    partitionCtx,
-                                    propertiesArray[i],
-                                    systemPropertiesArray[i],
-                                    enqueuedTimeUtcList.get(i),
-                                    offsetList.get(i)
-                            ).parsedEvent()
-                    );
+            if (payloads[i] != null) {
+                events
+                        .add(
+                                new EventImpl(
+                                        payloads[i],
+                                        partitionCtx,
+                                        propertiesArray[i],
+                                        systemPropertiesArray[i],
+                                        enqueuedTimeUtcList.get(i),
+                                        offsetList.get(i)
+                                ).parsedEvent()
+                        );
+            }
         }
         return events;
     }

--- a/src/main/java/com/teragrep/akv_01/plugin/Plugin.java
+++ b/src/main/java/com/teragrep/akv_01/plugin/Plugin.java
@@ -48,7 +48,9 @@ package com.teragrep.akv_01.plugin;
 import com.teragrep.akv_01.event.ParsedEvent;
 import com.teragrep.rlo_14.SyslogMessage;
 
+import java.util.List;
+
 public interface Plugin {
 
-    public abstract SyslogMessage syslogMessage(ParsedEvent parsedEvent);
+    public abstract List<SyslogMessage> syslogMessage(ParsedEvent parsedEvent);
 }

--- a/src/main/java/com/teragrep/akv_01/plugin/PluginStub.java
+++ b/src/main/java/com/teragrep/akv_01/plugin/PluginStub.java
@@ -48,10 +48,12 @@ package com.teragrep.akv_01.plugin;
 import com.teragrep.akv_01.event.ParsedEvent;
 import com.teragrep.rlo_14.SyslogMessage;
 
+import java.util.List;
+
 public final class PluginStub implements Plugin {
 
     @Override
-    public SyslogMessage syslogMessage(final ParsedEvent parsedEvent) {
+    public List<SyslogMessage> syslogMessage(final ParsedEvent parsedEvent) {
         throw new UnsupportedOperationException("Stub object does not implement any methods");
     }
 }

--- a/src/test/java/com/teragrep/akv_01/event/ParsedEventListFactoryTest.java
+++ b/src/test/java/com/teragrep/akv_01/event/ParsedEventListFactoryTest.java
@@ -54,10 +54,10 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 
-public final class ParsedEventArrayFactoryTest {
+public final class ParsedEventListFactoryTest {
 
     @Test
-    void testAsArrayMethod() {
+    void testAsListMethod() {
         final String payload = Json.createObjectBuilder().add("resourceId", "123").build().toString();
         final String[] payloads = new String[] {
                 payload, "string payload", payload
@@ -73,7 +73,7 @@ public final class ParsedEventArrayFactoryTest {
                 .asList("2010-01-01T00:00:00", "2020-01-01T01:02:03", "2030-04-07T12:34:10");
         final List<String> offsetList = Arrays.asList("0", "1", "2");
 
-        final ParsedEventArrayFactory arrayFactory = new ParsedEventArrayFactory(
+        final ParsedEventListFactory arrayFactory = new ParsedEventListFactory(
                 payloads,
                 partitionCtx,
                 propArray,
@@ -82,21 +82,22 @@ public final class ParsedEventArrayFactoryTest {
                 offsetList
         );
 
-        final ParsedEvent[] events = Assertions.assertDoesNotThrow(arrayFactory::asArray);
-        Assertions.assertEquals(3, events.length);
-        Assertions.assertEquals(JSONEvent.class, events[0].getClass());
-        Assertions.assertEquals(PlainEvent.class, events[1].getClass());
-        Assertions.assertEquals(JSONEvent.class, events[2].getClass());
-        Assertions.assertEquals(ZonedDateTime.of(2010, 1, 1, 0, 0, 0, 0, ZoneId.of("Z")), events[0].enqueuedTime());
-        Assertions.assertEquals(ZonedDateTime.of(2020, 1, 1, 1, 2, 3, 0, ZoneId.of("Z")), events[1].enqueuedTime());
-        Assertions.assertEquals(ZonedDateTime.of(2030, 4, 7, 12, 34, 10, 0, ZoneId.of("Z")), events[2].enqueuedTime());
-        Assertions.assertEquals("123", events[0].resourceId());
-        Assertions.assertThrows(UnsupportedOperationException.class, events[1]::resourceId);
-        Assertions.assertEquals("123", events[2].resourceId());
+        final List<ParsedEvent> events = Assertions.assertDoesNotThrow(arrayFactory::asList);
+        Assertions.assertEquals(3, events.size());
+        Assertions.assertEquals(JSONEvent.class, events.get(0).getClass());
+        Assertions.assertEquals(PlainEvent.class, events.get(1).getClass());
+        Assertions.assertEquals(JSONEvent.class, events.get(2).getClass());
+        Assertions.assertEquals(ZonedDateTime.of(2010, 1, 1, 0, 0, 0, 0, ZoneId.of("Z")), events.get(0).enqueuedTime());
+        Assertions.assertEquals(ZonedDateTime.of(2020, 1, 1, 1, 2, 3, 0, ZoneId.of("Z")), events.get(1).enqueuedTime());
+        Assertions
+                .assertEquals(ZonedDateTime.of(2030, 4, 7, 12, 34, 10, 0, ZoneId.of("Z")), events.get(2).enqueuedTime());
+        Assertions.assertEquals("123", events.get(0).resourceId());
+        Assertions.assertThrows(UnsupportedOperationException.class, events.get(1)::resourceId);
+        Assertions.assertEquals("123", events.get(2).resourceId());
     }
 
     @Test
     void testEqualsContract() {
-        EqualsVerifier.forClass(ParsedEventArrayFactory.class).verify();
+        EqualsVerifier.forClass(ParsedEventListFactory.class).verify();
     }
 }


### PR DESCRIPTION
…essages

This change is due to being able to generate multiple SyslogMessages from one parsed event. Also changed arrays to list for more convenient processing.